### PR TITLE
Corrected the links to Documentations and Demo

### DIFF
--- a/js/script.js
+++ b/js/script.js
@@ -19,7 +19,7 @@ var messages = {
 	"Help": {
 		"Title": "Help",
 		"Subtitle": "Some useful Links",
-		"Message": "<p><a href='http://monogatari.hyuchia.com/documentation/'>Documentation</a> - Everything you need to know.</p><p><a href='http://monogatari.hyuchia.com/demo/'>Demo</a> - A simple Demo.</p>"
+		"Message": "<p><a href='https://monogatari.io/documentation//'>Documentation</a> - Everything you need to know.</p><p><a href='https://monogatari.io/demo/'>Demo</a> - A simple Demo.</p>"
 	}
 };
 

--- a/js/script.js
+++ b/js/script.js
@@ -19,7 +19,7 @@ var messages = {
 	"Help": {
 		"Title": "Help",
 		"Subtitle": "Some useful Links",
-		"Message": "<p><a href='https://monogatari.io/documentation//'>Documentation</a> - Everything you need to know.</p><p><a href='https://monogatari.io/demo/'>Demo</a> - A simple Demo.</p>"
+		"Message": "<p><a href='https://monogatari.io/documentation/'>Documentation</a> - Everything you need to know.</p><p><a href='https://monogatari.io/demo/'>Demo</a> - A simple Demo.</p>"
 	}
 };
 


### PR DESCRIPTION
They were links to: http://monogatari.hyuchia.com/
Changed them to the current website (https://monogatari.io), probably the main developers forgot to change them.

Posted about this on Utopian: https://utopian.io/utopian-io/@ahmadmanga/a-small-fix-for-monogatari-visual-novel-engine