### PR TITLE
Fix reset hard-coding engine.Label

### DIFF
--- a/js/monogatari.js
+++ b/js/monogatari.js
@@ -1385,7 +1385,6 @@ $_ready(function () {
 		storage = JSON.parse(storageStructure);
 
 		// Reset Conditions
-		engine.Label = "Start";
 		label = game[engine.Label];
 		engine.Step = -1;
 

--- a/js/monogatari.js
+++ b/js/monogatari.js
@@ -198,6 +198,10 @@ $_ready(function () {
 	// Set the label in which the game will start
 	label = game[engine.Label];
 
+	// Set the startLabel property, which will be used when
+	// the game is reset.
+	engine.startLabel = engine.Label;
+
 	// Set the volume of all the media components
 	musicPlayer.volume = settings.Volume.Music;
 	ambientPlayer.volume = settings.Volume.Music;
@@ -1385,6 +1389,7 @@ $_ready(function () {
 		storage = JSON.parse(storageStructure);
 
 		// Reset Conditions
+		engine.Label = engine.startLabel;
 		label = game[engine.Label];
 		engine.Step = -1;
 


### PR DESCRIPTION
When resetGame() is called, it hard-codes engine.Label to "Start", which overwrites what gets set in options.js and breaks any game that starts with a label other than "Start". This pull request removes that line of code so engine.Label remains what it was set as in options.js.