### PR TITLE
🐣 Add ability to use varibale replacement with {{}} in messages

### DIFF
--- a/core/lib/actions/Message.js
+++ b/core/lib/actions/Message.js
@@ -107,7 +107,9 @@ export class Message extends Action {
 			this.message.body = this.message.Message;
 		}
 
-		$_(`${Monogatari.selector} [data-screen="game"] #components`).append (Monogatari.component ('MESSAGE').render (this.message.title, this.message.subtitle, this.message.body));
+		$_(`${Monogatari.selector} [data-screen="game"] #components`).append (
+      Monogatari.replaceVariables(Monogatari.component ('MESSAGE').render (this.message.title, this.message.subtitle, this.message.body))
+    );
 
 		$_(`${Monogatari.selector} [data-ui="messages"]`).addClass ('animated');
 


### PR DESCRIPTION
Fixed from this: https://github.com/Monogatari/Monogatari/pull/76#issuecomment-477467633

Original message: 

Hello : ) I used this to create a jam game and it was great!

I wanted the ability to use variables in messages using handlebars {{}}, so I added it in. Thought it'd be helpful to others : )