### PR TITLE
Quit alert dialog is showing "true"

### DIFF
--- a/core/components/alert-modal/index.js
+++ b/core/components/alert-modal/index.js
@@ -9,7 +9,7 @@ class AlertDialog extends Component {
 		this.props = {
 			active: true,
 			message: '',
-			context: '',
+			context: null,
 			editable: false,
 			actions: []
 		};


### PR DESCRIPTION
Problem:
When you click the button quit, the alert dialog shows : "Do you want to quit ? true"

I had to dig quite a bit to understand the bug. It is caused by the context that is an empty string.
The PandoraComponent `get props()` getter returns `true` if the value of the prop is an empty string.
```
if (typeof value === 'string') {
    if (value === 'false') {
        value = false;
    } else if (value === 'true' || value === '') {
        value = true;
    } else if (!isNaN (value)) {
        if (value.indexOf ('.') > 0) {
            value = parseFloat (value);
        } else {
            value = parseInt (value);
        }
    }
}
```
A simple solution to this problem is to set the value of context to `null`. Hope it fits your good practices/guidelines :)
