### PR TITLE
Fix: Only half of the class are removed when showing character 

### DIFF
--- a/src/actions/ShowCharacter.js
+++ b/src/actions/ShowCharacter.js
@@ -89,10 +89,7 @@ export class ShowCharacter extends Action {
 		if (this.engine.element ().find (`[data-character="${this.asset}"]`).isVisible ()) {
 			this.engine.element ().find (`[data-character="${this.asset}"]`).attribute ('src', `${this.engine.setting ('AssetsPath').root}/${this.engine.setting ('AssetsPath').characters}/${directory}${this.image}`);
 
-			const classList = [];
-			this.engine.element ().find (`[data-character="${this.asset}"]`).get(0).classList.forEach(oldClass => {
-				classList.push (oldClass);
-			});
+			const classList = [...this.engine.element ().find (`[data-character="${this.asset}"]`).get(0).classList];
 
 			for (const oldClass of classList) {
 				if (this.classes.indexOf (oldClass) === -1) {

--- a/src/actions/ShowCharacter.js
+++ b/src/actions/ShowCharacter.js
@@ -89,7 +89,10 @@ export class ShowCharacter extends Action {
 		if (this.engine.element ().find (`[data-character="${this.asset}"]`).isVisible ()) {
 			this.engine.element ().find (`[data-character="${this.asset}"]`).attribute ('src', `${this.engine.setting ('AssetsPath').root}/${this.engine.setting ('AssetsPath').characters}/${directory}${this.image}`);
 
-			const classList = this.engine.element ().find (`[data-character="${this.asset}"]`).get(0).classList;
+			const classList = [];
+			this.engine.element ().find (`[data-character="${this.asset}"]`).get(0).classList.forEach(oldClass => {
+				classList.push (oldClass);
+			});
 
 			for (const oldClass of classList) {
 				if (this.classes.indexOf (oldClass) === -1) {


### PR DESCRIPTION
When removing classes from a character using a show command, only half of the classes were removed.

Exemple : 
```
'show character r normal left with move 1 2 3 4 5 6 7 8 9',
'show character r normal right',
```

After the second statement, my character still had the classes `move 2 4 6 8`

When calling `sprite.removeClass (oldClass);`, this was affecting the `classList` because classList was directly referencing the the sprite's class list. The bug is fixed by copying this classList DOMTokenList in a brand new array.