### PR TITLE
Character move transition

### DIFF
--- a/src/actions/ShowCharacter.js
+++ b/src/actions/ShowCharacter.js
@@ -109,6 +109,14 @@ export class ShowCharacter extends Action {
 				this.engine.element ().find (`[data-character="${this.asset}"]`).style ('animation-duration', '');
 			}
 
+			const transitionPosition = this.classes.indexOf ('transition');
+
+			if (transitionPosition > -1) {
+				this.engine.element ().find (`[data-character="${this.asset}"]`).style ('transition-duration', this.classes[transitionPosition + 1]);
+			} else {
+				this.engine.element ().find (`[data-character="${this.asset}"]`).style ('transition-duration', '');
+			}
+
 			this.engine.element ().find (`[data-character="${this.asset}"]`).data ('sprite', this.sprite);
 
 		} else {

--- a/src/components/game-screen/index.css
+++ b/src/components/game-screen/index.css
@@ -42,18 +42,21 @@ game-screen {
 	}
 
 	[data-sprite] {
-		margin: 0 auto;
-		left: 0;
-		right: 0;
+		left: 50%;
+		transform: translateX(-50%);
 
 		&.right {
-			left: initial;
-			right: 0;
+			left: 100%;
+			transform: translateX(-100%);
 		}
 
 		&.left {
-			left: 0;
-			right: initial;
+			left: 0%;
+			transform: translateX(0%);
+		}
+
+		&.move {
+			transition:all 0.2s ease;
 		}
 	}
 


### PR DESCRIPTION
This tries to implement transitions between two characters states. There may be a better way to do this.

This uses a simple syntax, a move class that could be applied with the `with` keyword.

**Example**
```
show character <character_id> <sprite_id> // The character spawns in the middle
show character <character_id> <sprite_id> at right with move // The character is smoothly moved to the right
```

**How it works**
To do this, we apply a transition css property to animate the css properties that are changing when we apply the `right` class.

For the animation to work properly, all the position classes have to use the same properties for positioning. I chose to use the `left` and `transform` properties for this.

**Discussion points**
- To let the user chose the transition duration he wants, I've duplicated the keyword `duration` logic into a new `transition` keyword (ex: `show character r normal left with move transition 0.5s`), but maybe we could simply make the `duration` keyword apply both `animation-duration` and `transition-duration` properties
- Maybe we should restrict the transition to the position properties ? Using something like 
```css
&.move {
	transition-property:left, transform;
	transition-duration: 0.2s;
	transition-timing-function: ease;
}
```
- It would be great if we provided a way to change the transition-timing-function easily ? For now it uses `ease`, the default  one :) 
