### PR TITLE
background: fix loading background along with scene

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -38,6 +38,7 @@
 		"no-unused-vars": [1, { "args": "after-used" }]
     },
     "env": {
+		"cypress/globals": true,
         "es6": true,
         "browser": true
     },
@@ -51,5 +52,8 @@
 			"configFile": "./.babelrc"
 		}
 	},
+	"plugins": [
+		"cypress"
+	],
     "extends": "eslint:recommended"
 }

--- a/package.json
+++ b/package.json
@@ -98,6 +98,7 @@
 		"dotenv": "^11.0.0",
 		"electron-notarize": "^1.1.1",
 		"eslint": "^8.6.0",
+		"eslint-plugin-cypress": "^2.12.1",
 		"htmlhint": "^1.1.0",
 		"jsdoc": "^3.6.7",
 		"parcel": "^2.1.1",

--- a/src/actions/ShowBackground.js
+++ b/src/actions/ShowBackground.js
@@ -16,8 +16,8 @@ export class ShowBackground extends Action {
 	}
 
 	static onLoad () {
-		const { background, scene } = this.engine.state ();
-		if (typeof background === 'string' && background !== '' && scene === '') {
+		const { background } = this.engine.state ();
+		if (typeof background === 'string' && background !== '') {
 			const action = this.engine.prepareAction (background, { cycle: 'Application' });
 			return action.willApply ().then (() => {
 				return action.apply ().then (() => {

--- a/src/components/save-slot/index.js
+++ b/src/components/save-slot/index.js
@@ -124,16 +124,13 @@ class SaveSlot extends Component {
 			// @Compatibility [<= v1.4.1]
 			// That last if checking for the existance of game in the data is
 			// required because older versions do not have that property.
-			if (this.data.game.state.scene) {
-				background = this.data.game.state.scene;
 
-				if (background.indexOf (' with ') > -1) {
-					background = Text.prefix (' with ', background);
-				}
+			// eslint-disable-next-line
+			console.debug('SaveSlot.render', this.data.game.state.background, this.data.game.state.scene);
 
-				background = Text.suffix ('show scene', background);
-
-			} else if (this.data.game.state.background) {
+			if (this.data.game.state.background) {
+				// eslint-disable-next-line no-console
+				console.debug('this.data.game.state.background case');
 				background = this.data.game.state.background;
 
 				if (background.indexOf (' with ') > -1) {
@@ -141,6 +138,16 @@ class SaveSlot extends Component {
 				}
 
 				background = Text.suffix ('show background', background);
+			} else if (this.data.game.state.scene) {
+				// eslint-disable-next-line no-console
+				console.debug('this.data.game.state.scene case');
+				background = this.data.game.state.scene;
+
+				if (background.indexOf (' with ') > -1) {
+					background = Text.prefix (' with ', background);
+				}
+
+				background = Text.suffix ('show scene', background);
 			}
 		}
 		return `

--- a/yarn.lock
+++ b/yarn.lock
@@ -3259,6 +3259,13 @@ escodegen@^1.11.0:
   optionalDependencies:
     source-map "~0.6.1"
 
+eslint-plugin-cypress@^2.12.1:
+  version "2.12.1"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-cypress/-/eslint-plugin-cypress-2.12.1.tgz#9aeee700708ca8c058e00cdafe215199918c2632"
+  integrity sha512-c2W/uPADl5kospNDihgiLc7n87t5XhUbFDoTl6CfVkmG+kDAb5Ux10V9PoLPu9N+r7znpc+iQlcmAqT1A/89HA==
+  dependencies:
+    globals "^11.12.0"
+
 eslint-scope@^5.1.1:
   version "5.1.1"
   resolved "https://registry.yarnpkg.com/eslint-scope/-/eslint-scope-5.1.1.tgz#e786e59a66cb92b3f6c1fb0d508aab174848f48c"
@@ -3835,7 +3842,7 @@ global-tunnel-ng@^2.7.1:
     npm-conf "^1.1.3"
     tunnel "^0.0.6"
 
-globals@^11.1.0:
+globals@^11.1.0, globals@^11.12.0:
   version "11.12.0"
   resolved "https://registry.yarnpkg.com/globals/-/globals-11.12.0.tgz#ab8795338868a0babd8525758018c2a7eb95c42e"
   integrity sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==


### PR DESCRIPTION
### Why this PR is needed?

#### To reproduce my issue
1. Create a script with scene and background together, for example:
    ```javascript
    monogatari.script ({
	// The game starts here.
	'Start': [
		'show scene #555555 with fadeIn',
		'show background phone.jpg with fadeIn',
		'Hello.',
		'Time to test saving',
		'After save',
         ],
    });
    ```
2. Run the game.
3. When you see "Hello.", save the game.
4. After save, simply load the newly saved game.

#### Expected behaviour
See the word "Hello" with the background "phone.jpg".

#### Actual behaviour
See the word "Hello" with the background color #555555. No phone.jpg.

### What this PR does?
* Background should be of higher priority than scene. So the presents
  of Scene should not prevent Background from taking effect.