### PR TITLE
Fix textbox show UI bug

### DIFF
--- a/src/monogatari.js
+++ b/src/monogatari.js
@@ -2456,7 +2456,7 @@ class Monogatari {
 				this.element ().find ('[data-component="quick-menu"] [data-action="distraction-free"] [data-string]').text (this.string ('Hide'));
 				this.element ().find ('[data-component="quick-menu"] [data-action="distraction-free"] [data-icon]').replaceWith ('<span class="fas fa-eye" data-action="distraction-free"></span>');
 				this.element ().find ('[data-component="quick-menu"]').removeClass ('transparent');
-				this.element ().find ('[data-component="text-box"]').show ();
+				this.element ().find ('[data-component="text-box"]').show ('grid');
 				this.global ('distraction_free', false);
 			} else {
 				this.element ().find ('[data-component="quick-menu"] [data-action="distraction-free"] [data-string]').text (this.string ('Show'));


### PR DESCRIPTION
When showing the UI, the display is set to `block` instead of `grid`